### PR TITLE
Fix shebang from sh to bash

### DIFF
--- a/ssm-agent.sh
+++ b/ssm-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 role_name="ssm-bastion-activation"
 default_instance_name="ssm-bastion"


### PR DESCRIPTION
shebang が `sh` だと動かなかったため bash に変更。